### PR TITLE
Feature: Add Google Analytics support

### DIFF
--- a/extensions/site.json
+++ b/extensions/site.json
@@ -76,5 +76,11 @@
       "variableName":"disqus_shortname",
       "inputFieldHeight":22,
       "exampleText":"disqus shortname"
+   },
+   {
+    "title": "google analytics",
+    "variableName": "ga_code",
+    "inputFieldHeight": 100,
+    "exampleText": "Google Analytics tracking code"
    }
 ]

--- a/header.html
+++ b/header.html
@@ -12,6 +12,9 @@
   </title>
   {% if post.ext_seo_keywords.length %}<meta name="keywords" content="{{post.ext_seo_keywords}}" />{% /if %}
   {% if post.ext_seo_des.length %}<meta name="description" content="{{post.ext_seo_des}}" />{% /if %}
+  {% if ext_ga_code.length %}
+  {{ ext_ga_code }}
+  {% /if %}
   <link href="atom.xml" rel="alternate" title="{{ siteName }}" type="application/atom+xml">
     <link rel="stylesheet" href="asset/css/foundation.min.css" />
     <link rel="stylesheet" href="asset/css/docs.css" />


### PR DESCRIPTION
Issue: https://github.com/oulvhai/mweb-medium-like/issues/5

- Add new variable named ga_code in `site.json`.
- `header.html` will render ext_ga_code if exists.
- Just pasted the tracking code in setting and it will work.